### PR TITLE
#21: Fix panic button ENDPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Supported functions:
 - Arm partial (away/night)
 - Disarm
 - Get alarm status
+- Trigger alarm panic button
 
 ### Usage
 Create a client with:

--- a/yalesmartalarmclient/auth.py
+++ b/yalesmartalarmclient/auth.py
@@ -17,9 +17,9 @@ class YaleAuth:
     """
     YALE_CODE_RESULT_SUCCESS = '000'
 
-    _HOST = "https://mob.yalehomesystem.co.uk/yapi"
-    _ENDPOINT_TOKEN = "/o/token/"
-    _ENDPOINT_SERVICES = "/services/"
+    _HOST = "https://mob.yalehomesystem.co.uk"
+    _ENDPOINT_TOKEN = "/yapi/o/token/"
+    _ENDPOINT_SERVICES = "/yapi/services/"
     _YALE_AUTH_TOKEN = 'VnVWWDZYVjlXSUNzVHJhcUVpdVNCUHBwZ3ZPakxUeXNsRU1LUHBjdTpkd3RPbE15WEtENUJ5ZW1GWHV0am55eGhrc0U3V0ZFY2p0dFcyOXRaSWNuWHlSWHFsWVBEZ1BSZE1xczF4R3VwVTlxa1o4UE5ubGlQanY5Z2hBZFFtMHpsM0h4V3dlS0ZBcGZzakpMcW1GMm1HR1lXRlpad01MRkw3MGR0bmNndQ=='
 
     _YALE_AUTHENTICATION_REFRESH_TOKEN = 'refresh_token'
@@ -51,7 +51,7 @@ class YaleAuth:
             endpoint: parts of an url
 
         Returns:
-            a dictionary with the reponse.
+            a dictionary with the response.
 
         """
         url = self._HOST + endpoint

--- a/yalesmartalarmclient/client.py
+++ b/yalesmartalarmclient/client.py
@@ -32,9 +32,9 @@ class AuthenticationError(Exception):
 class YaleSmartAlarmClient:
     YALE_CODE_RESULT_SUCCESS = '000'
 
-    _ENDPOINT_GET_MODE = "/api/panel/mode/"
-    _ENDPOINT_SET_MODE = "/api/panel/mode/"
-    _ENDPOINT_DEVICES_STATUS = "/api/panel/device_status/"
+    _ENDPOINT_GET_MODE = "/yapi/api/panel/mode/"
+    _ENDPOINT_SET_MODE = "/yapi/api/panel/mode/"
+    _ENDPOINT_DEVICES_STATUS = "/yapi/api/panel/device_status/"
     _ENDPOINT_PANIC_BUTTON = "/api/panel/panic"
 
     _REQUEST_PARAM_AREA = "area"


### PR DESCRIPTION
@domwillcode while testing the panic button trigger in HASS I noticed that the request is sent to a wrong URL

It sent the request to:
```
https://mob.yalehomesystem.co.uk/yapi/api/panel/panic
```
but the correct URL is:
```
https://mob.yalehomesystem.co.uk/api/panel/panic
```

I have looked around and from what can I see the following changes are the only way of fixing this endpoint.

Can you see any issue?