### PR TITLE
added backoff

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     download_url='https://github.com/domwillcode/yale-smart-alarm-client',
     keywords=['alarm', 'Yale', 'Smart Alarm'],
     package_data={'': ['data/*.json']},
-    install_requires=['requests>=2.0.0'],
+    install_requires=['requests>=2.0.0','backoff==1.10.0'],
     packages=setuptools.find_packages(),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Hello,

Starting to work on updating the Yale component in Home Assistant. When switching to 0.3.1 I noticed that backoff was not being installed causing an error. I was able to get around this by manually installing backoff but it would be best if your yale api client installed it. This PR should take care of that.  

Thanks