### PR TITLE
Add python 3.7 compatibility

### DIFF
--- a/yalesmartalarmclient/auth.py
+++ b/yalesmartalarmclient/auth.py
@@ -1,7 +1,12 @@
 """Module for handling authentication against the Yale Smart API."""
 import logging
-from typing import Any, Dict, Literal, Optional, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+    
 import backoff
 import requests
 


### PR DESCRIPTION
Make the code compatible with python 3.7.  Literal is only available in typing on python >=3.8.  This is the only change needed for 3.7 compatibility.